### PR TITLE
Fix crash caused by scRNA metrics lacking description

### DIFF
--- a/multiqc/modules/dragen/sc_rna_metrics.py
+++ b/multiqc/modules/dragen/sc_rna_metrics.py
@@ -23,6 +23,7 @@ METRICS = [
         in_genstats="#",
         in_own_tabl="#",
         precision=0,
+        descr=m
     )
     for m in METRIC_NAMES
 ]

--- a/multiqc/modules/dragen/utils.py
+++ b/multiqc/modules/dragen/utils.py
@@ -120,7 +120,7 @@ def make_headers(parsed_metric_ids, metrics):
         elif metric.unit == "%":
             col["suffix"] = " %"
             col["format"] = "{:,.1f}"
-        elif any(metric.descr.startswith(pref) for pref in ("Total number of ", "The number of ", "Number of ")):
+        elif any((metric.descr and metric.descr.startswith(pref)) for pref in ("Total number of ", "The number of ", "Number of ")):
             col["format"] = "{:,.0f}"
         if metric.precision is not None:
             col["format"] = "{:,." + str(metric.precision) + "f}"


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated

<!-- If this PR is for a NEW module - delete if not -->

- [ ] There is example tool output for tools in the <https://github.com/ewels/MultiQC_TestData> repository or attached to this PR
- [ ] Code is tested and works locally (including with `--lint` flag)
- [ ] `docs/README.md` is updated with link to below
- [ ] `docs/modulename.md` is created
- [ ] Everything that can be represented with a plot instead of a table is a plot
- [ ] Report sections have a description and help text (with `self.add_section`)
- [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [ ] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
- [ ] Module does not do any significant computational work
