### PR TITLE
Fix crash in mapping bar-plot generation due to missing metric

### DIFF
--- a/multiqc/modules/dragen/mapping_metrics.py
+++ b/multiqc/modules/dragen/mapping_metrics.py
@@ -373,7 +373,6 @@ def parse_mapping_metrics_file(f):
     for data in itertools.chain(data_by_readgroup.values(), data_by_phenotype.values()):
         # fixing when deduplication wasn't performed, or running with single-end data
         for field in [
-            "Number of duplicate marked reads",
             "Number of duplicate marked and mate reads removed",
             "Number of unique reads (excl. duplicate marked reads)",
             "Mismatched bases R2 (excl. indels)",


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated

<!-- If this PR is for a NEW module - delete if not -->

- [ ] There is example tool output for tools in the <https://github.com/ewels/MultiQC_TestData> repository or attached to this PR
- [ ] Code is tested and works locally (including with `--lint` flag)
- [ ] `docs/README.md` is updated with link to below
- [ ] `docs/modulename.md` is created
- [ ] Everything that can be represented with a plot instead of a table is a plot
- [ ] Report sections have a description and help text (with `self.add_section`)
- [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [ ] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
- [ ] Module does not do any significant computational work
